### PR TITLE
fix(doc): add required `engine` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This engine exposes configuration options through the [Boxfile](http://docs.nano
 #### Overview of Boxfile Configuration Options
 ```yaml
 run.config:
+  engine: nodejs
   engine.config:
     runtime: nodejs-4.4
 ```

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Specifies which Node.js runtime and version to use. The following runtimes are a
 
 ```yaml
 run.config:
+  engine: nodejs
   engine.config:
-    runtime: nodejs-4.4
+    runtime: nodejs-6.2
 ```
 
 ---


### PR DESCRIPTION
Otherwise nanobox errors saying that it's required.